### PR TITLE
docs: Fix link on UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,1 +1,1 @@
-This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading). It's also available in this repository on [/docs/02-app/01-building-your-application/11-upgrading](/docs/02-app/01-building-your-application/11-upgrading).
+This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading). It's also available in this repository on [/docs/01-app/01-building-your-application/11-upgrading](/docs/02-app/01-building-your-application/11-upgrading).


### PR DESCRIPTION
### What?

Fix the upgrade instructions in `UPGRADING.md`.

### Why?

The `/docs/02-app` path does not exist.